### PR TITLE
Check flow criterion, improve error handling and test with BAZI examples

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 * add `district_winner_matrix()` function
 * returned seat values from proporz/biproporz functions are always integer
+* undefined biproporz results are caught earlier (flow criterion check)
 
 # proporz 1.5.0
 

--- a/R/biproportional.R
+++ b/R/biproportional.R
@@ -388,11 +388,7 @@ lower_apportionment = function(votes_matrix, seats_cols,
     } else if(method == "wto") {
         round_func = create_wto_round_function(votes_matrix, seats_cols, seats_rows)
     } else {
-        method_impl <- get_method_implementation(method)
-        if(method_impl != "divisor_round") {
-            warning('Lower apportionment is only guaranteed to terminate with the default ',
-                    'Sainte-Lagu\u00EB/Webster method (method = "round")', call. = FALSE)
-        }
+        method_impl = get_method_implementation(method)
         round_func = get_round_function(method_impl)
     }
 

--- a/R/biproportional.R
+++ b/R/biproportional.R
@@ -442,7 +442,7 @@ divide_votes_matrix = function(M, col_divisors, row_divisors) {
 find_matrix_divisors = function(M, seats_cols, seats_rows, round_func) {
     assert(is.matrix(M))
     assert(is.matrix(round_func(M)))
-    check_enough_biproporz_seats(M, seats_cols, seats_rows)
+    check_flow_criterion(M, seats_cols, seats_rows)
 
     # divisor parties
     dR = rep(1, nrow(M))

--- a/R/biproportional.R
+++ b/R/biproportional.R
@@ -479,10 +479,18 @@ find_matrix_divisors = function(M, seats_cols, seats_rows, round_func) {
 
     # usually less than 20 iterations are needed
     max_iter = getOption("proporz_max_iterations", 1000)
+    target_diff_prev = sum(2*seats_cols)
     for(i in seq_len(max_iter)) {
-        if(all(c(mc(M,dC,dR) == seats_cols, mr(M,dC,dR) == seats_rows))) {
+        # break conditions
+        target_diff = sum(abs(mc(M,dC,dR) - seats_cols)) + sum(abs(mr(M,dC,dR) - seats_rows))
+        if(target_diff > target_diff_prev) {
+            stop("Result is undefined, cannot assign all seats in lower apportionment", call. = FALSE)
+        }
+        target_diff_prev <- target_diff
+        if(sum(target_diff) == 0) {
             return(list(cols = dC, rows = dR))
         }
+
         # change party divisors
         row_decr = which.min0(mr(M,dC,dR) - seats_rows)
         if(length(row_decr) == 1) {
@@ -548,10 +556,6 @@ find_divisor = function(votes,
     }
 
     divisor_range = sort(c(divisor_from, divisor_to))
-
-    if(any(is.infinite(votes)) || any(is.nan(votes))) {
-        stop("Result is undefined, cannot assign all seats in lower apportionment", call. = FALSE)
-    }
 
     # Divisors should be within votes/(seats-1) and votes/(seats+1).
     # It might be necessary to increase the search range given that

--- a/R/biproportional.R
+++ b/R/biproportional.R
@@ -453,9 +453,10 @@ find_matrix_divisors = function(M, seats_cols, seats_rows, round_func) {
     dR.max = rep(1.5, nrow(M))
 
     # divisor districts
-    dC = round(colSums(M)/seats_cols)
+    dC = unname(round(colSums(M)/seats_cols))
     dC[is.nan(dC)] <- 0
     dC.min = floor(colSums(M)/(seats_cols+1) / max(dR.max))
+    dC.min[dC.min == 0] <- 0.1 # will be lowered in find_divisor if necessary
     dC.max = ceiling(colSums(M)/(seats_cols-1) / min(dR.min))
 
     # handle districts with only one seat (otherwise leads to infinite dC.max)

--- a/R/biproportional.R
+++ b/R/biproportional.R
@@ -446,6 +446,7 @@ divide_votes_matrix = function(M, col_divisors, row_divisors) {
 find_matrix_divisors = function(M, seats_cols, seats_rows, round_func) {
     assert(is.matrix(M))
     assert(is.matrix(round_func(M)))
+    check_enough_biproporz_seats(M, seats_cols, seats_rows)
 
     # divisor parties
     dR = rep(1, nrow(M))

--- a/R/utils.R
+++ b/R/utils.R
@@ -107,12 +107,31 @@ assert = function(check) {
     invisible()
 }
 
-collapse_names = function(x) {
-    if(is.character(x)) {
-        y = paste(x, collapse = "', '")
-        y <- paste0("'", y, "'")
-    } else {
-        y = paste(x, collapse = ", ")
+collapse_names = function(x, x_names = NULL) {
+    if(is.logical(x)) {
+        x <- which(x)
     }
-    return(y)
+    if(!is.null(x_names)) {
+        assert(is.numeric(x))
+        x <- x_names[x]
+    }
+
+    if(is.character(x)) {
+        out = paste(x, collapse = "', '")
+        out <- paste0("'", out, "'")
+    } else {
+        out = paste(x, collapse = ", ")
+    }
+
+    return(out)
+}
+
+num_word = function(singular, plural, i) {
+    if(is.logical(i)) {
+        i <- which(i)
+    }
+    if(length(i) == 1L) {
+        return(singular)
+    }
+    return(plural)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -16,7 +16,7 @@ bisect = function(f, x1, x2, tol = 1e-9, max_iterations = 1000) {
             x2 <- x
         }
     }
-    stop("Exceeded maximum number of iterations (", max_iterations, ")") # nocov
+    stop("Exceeded maximum number of bisection iterations (", max_iterations, ")") # nocov
 }
 
 #' Pivot long data.frame to wide matrix and vice versa

--- a/inst/bazi.R
+++ b/inst/bazi.R
@@ -1,0 +1,195 @@
+# Read a bazi data file
+read_bazi_data = function(file.bazi) {
+	lines = readLines(file.bazi, warn = FALSE, encoding = "UTF-8")
+	stopifnot(all(!grepl("::TOKEN::", lines)))
+
+	vals = .get_token_values(lines)
+	vals$filename <- file.bazi
+
+	if(length(unique(names(vals))) == length(vals)) {
+		if(strcount(vals$DATEN, "\n\\+") <= 2) {
+			vals <- .parse_bazi_single_district(vals)
+		} else {
+			# district data per party
+			vals <- .parse_bazi_single_district_party_fill(vals)
+		}
+	} else {
+		vals <- .parse_bazi_multiple_districts(vals)
+	}
+
+	class(vals) <- c("bazi_data", "list")
+
+	return(vals)
+}
+
+# parse bazi files ####
+.get_token_values = function(lines) {
+	lines <- trimws(lines)
+
+	# rename tokens
+	lines <- lines |>
+		gsub.("=TITLE=", "=TITEL=") |>
+		gsub.("=METHOD=", "=METHODE=") |>
+		gsub.("=INPUT=", "=EINGABE=") |>
+		gsub.("=OUTPUT=", "=AUSGABE=") |>
+		gsub.("=DISTRICT=", "=DISTRIKT=") |>
+		gsub.("=DISTRICTOPTION=", "=DISTRIKTOPTION=") |>
+		gsub.("=SEATS=", "=MANDATE=") |>
+		gsub.("=DATA=", "=DATEN=") |>
+		gsub.("=END=", "=ENDE=") |>
+		gsub.("=ENCODING=", "=KODIERUNG=") |>
+		gsub.("=ACCURACY=", "=GENAUIGKEIT=")
+
+	# trim to end
+	end_index = which(lines == "=ENDE=")
+	stopifnot(length(end_index) == 1)
+	lines <- lines[1:end_index]
+
+	# all tokens
+	tokens = c("TITEL", "METHODE", "AUSGABE", "EINGABE", "DISTRIKTOPTION",
+			   "DISTRIKT", "MANDATE", "MANDATES",
+			   "DATEN", "INFO", "PATTS", "KODIERUNG", "GENAUIGKEIT")
+
+	# sanitize info
+	info_index = which(startsWith(lines, "=INFO="))
+	if(length(info_index) > 0) {
+		for(token in tokens) {
+			info_range = seq(info_index+1, end_index-1)
+			lines[info_range] <- gsub(
+				paste0("=", token, "="),
+				paste0("", token," \n"),
+				lines[info_range], ignore.case = TRUE)
+		}
+	}
+
+	# find relevant tokens
+	txt = paste0(lines, collapse = "\n")
+	for(token in tokens) {
+		txt <- gsub(paste0("=", token, "="),
+					paste0("::TOKEN::",token,"\n"),
+					txt, ignore.case = TRUE)
+	}
+	stopifnot(!any(grepl("\n=[A-Z]+=", gsub("=ENDE=", "", txt))))
+	tokenized_lines = strsplit1(txt, "\n")
+
+	# create list from tokens
+	token_index = which(startsWith(tokenized_lines, "::TOKEN::"))
+	token_index <- c(token_index, length(tokenized_lines))
+	stopifnot(tokenized_lines[length(tokenized_lines)] == "=ENDE=")
+
+	token_data_list = list()
+	token_names = list()
+	for(i in seq(1, length(token_index)-1)) {
+		from = token_index[i]+1
+		to = token_index[i+1]-1
+		data_lines = trimws(tokenized_lines[seq(from, to)])
+		data_lines <- data_lines[data_lines != "" & data_lines != " "]
+
+		name = gsub("::TOKEN::", "", tokenized_lines[token_index[i]])
+		data = paste(data_lines, collapse = "\n")
+
+		token_names[[length(token_names)+1]] <- name
+		token_data_list[[length(token_data_list)+1]] <- data
+	}
+
+	names(token_data_list) <- token_names
+	return(token_data_list)
+}
+
+.parse_bazi_single_district = function(vals) {
+	vals$data <- .read.table_bazi(vals$DATEN)
+	cns = trimws(strsplit1(vals$EINGABE, ","))
+	colnames(vals$data) <- cns[seq(1,ncol(vals$data))]
+	vals$seats <- suppressWarnings(as.integer(vals$MANDATE))
+	vals
+}
+
+.parse_bazi_single_district_party_fill = function(vals) {
+	vals$DATEN <- gsub("\n\\+", "\n\\+ ", vals$DATEN)
+	vals$data <- .read.table_bazi(vals$DATEN)
+
+	vals$data[[1]] <- fill_plus(vals$data[[1]])
+	cns = trimws(strsplit1(vals$EINGABE, ","))
+	if(length(cns) == ncol(vals$data) && cns[length(cns)] == "---") {
+		cns <- cns[-length(cns)]
+	}
+
+	colnames(vals$data) <- c(cns[1], "DISTRIKT",
+							 cns[2:length(cns)])
+
+	vals$seats <- suppressWarnings(as.integer(vals$MANDATE))
+
+	vals
+}
+
+.parse_bazi_multiple_districts = function(vals) {
+	# more than one disctrict data
+	distrikt_mandate_daten = vals[names(vals) %in% c("DISTRIKT", "MANDATE", "DATEN")]
+	stopifnot(length(unique(table(names(distrikt_mandate_daten)))) == 1)
+
+	# split into sets of three
+	district_data_list = split(distrikt_mandate_daten,
+							   rep(seq_len(length(distrikt_mandate_daten)/3), each = 3))
+
+	# data votes
+	data_list = district_data_list |>
+		lapply(\(dmd) {
+			x = strsplit1(dmd$DATEN, "\n")
+			x <- gsub.(x, "^\\+", "")
+			x <- lapply(x, \(x) {
+				if(!grepl('"', dmd$DISTRIKT)) {
+					return(paste0('"', dmd$DISTRIKT, '" ', x))
+				} else if(!grepl("'", dmd$DISTRIKT)) {
+					return(paste0("'", dmd$DISTRIKT, "' ", x))
+				}
+				stop() # nocov
+			})
+			unlist(x)
+		}) |> unlist(use.names = F)
+
+	vals$data <- data_list |>
+		lapply(\(txt) {
+			read.table(text = txt, fill = TRUE,
+					   col.names = c("DISTRIKT", trimws(strsplit1(vals$EINGABE, ","))))
+		}) |>
+		rbind_list()
+
+	# district seats
+	vals$seats <- district_data_list |>
+		lapply(\(dmd) {
+			data.frame(district = dmd$DISTRIKT, seats = as.integer(dmd$MANDATE))
+		}) |>
+		rbind_list()
+
+	vals
+}
+
+.read.table_bazi = function(text) {
+	read.table(text = text, fill = TRUE, header = FALSE, row.names = NULL)
+}
+
+# utils ####
+strsplit1 = function(x, split, fixed = FALSE) {
+	strsplit(x, split, fixed = fixed)[[1]]
+}
+
+rbind_list = function(l) {
+	do.call(rbind, l)
+}
+
+gsub. = function(x, pattern, replacement, ignore.case = TRUE) {
+	gsub(pattern, replacement, x, ignore.case = ignore.case)
+}
+
+fill_plus = function(x) {
+	values = x[x != "+"]
+	y = rep(1, length(x))
+	y[x == "+"] <- 0
+	lvls = cumsum(y)
+
+	values[lvls]
+}
+
+strcount = function(x, pattern) {
+	length(gregexpr(pattern, x)[[1]])
+}

--- a/inst/test-bazi_biproportional_examples.R
+++ b/inst/test-bazi_biproportional_examples.R
@@ -1,0 +1,135 @@
+# Load all biproportional example datasets from BAZI and run them
+# with biproporz. The apportionment results are not validated, this
+# script is intended to find unexpected errors.
+# Bazi data has to be extracted to "data/" directory
+
+source("bazi.R")
+
+library(proporz)
+
+# Setup functions ####
+get_proporz_method = function(bazi_data) {
+    if(!is.null(bazi_data$DISTRIKTOPTION) && tolower(bazi_data$DISTRIKTOPTION) == "nzz") {
+        return("nzz")
+    }
+
+    data_method = tolower(gsub(" ", "", bazi_data$METHODE))
+    if(data_method == "divstd") {
+        method = list("round", "round")
+    } else if(data_method == "divauf") {
+        method = "divisor_ceiling"
+    } else if(data_method == "divabr") {
+        method = "divisor_floor"
+    } else if(data_method == "divgeo") {
+        method = "divisor_geometric"
+    } else if(data_method == "divstd,divabr") {
+        method = list("divisor_round", "divisor_floor")
+    } else if(data_method == "divabr,divstd") {
+        method = list("divisor_floor", "divisor_round")
+    } else {
+        stop(bazi_data$METHODE)
+    }
+    return(method)
+}
+
+# Neue Zürcher Zuteilungsmethode
+nzz = function(vm, ds) {
+    weighted_votes_matrix = weight_list_votes(vm, ds)
+    # weighted votes are rounded with the nzz method
+    rounded_matrix = ceil_at(weighted_votes_matrix, 0.5)
+    seats_party = proporz(rowSums(rounded_matrix), sum(ds), "round")
+
+    seats_matrix = lower_apportionment(vm, ds, seats_party)
+    t(seats_matrix)
+}
+
+# function to run pukelsheim with bazi_data
+pukelsheim_bazi = function(bazi_data) {
+    method = get_proporz_method(bazi_data)
+
+    # datasets using voter counts are not described in the data files
+    use_list_vote_false = c(
+        "data/zTest_data/NZZ_problems/Tied_cases/AS1.bazi",
+        "data/zTest_data/NZZ_problems/Tied_cases/AH2.bazi",
+        "data/zTest_data/Biproportional_problems/Tied_cases/FP6.bazi",
+        "data/zTest_data/Biproportional_problems/Nonexistence/FG3.bazi",
+        "data/zTest_data/Biproportional_problems/Nonexistence/NE4.bazi",
+        "data/zTest_data/Biproportional_problems/Nonexistence/Gassner2000-62Exemple24.bazi",
+        "data/zTest_data/NZZ_problems/AH1-AH14/AH14.bazi"
+    )
+    use_list_votes = !bazi_data$filename %in% use_list_vote_false
+
+    # run biproporz
+    vm = pivot_to_matrix(bazi_data$data[,c(2,1,3)])
+    ds = setNames(bazi_data$seats$seats, bazi_data$seats$district)
+
+    if("nzz" %in% unlist(method)) {
+        if(!use_list_votes) {
+            method <- "round"
+        } else {
+            return(nzz(vm, ds))
+        }
+    }
+    seats = biproporz(vm, ds, method = method,
+                      use_list_votes = use_list_votes)
+    t(seats)
+}
+
+load_bazi_dir = function(path) {
+    bazi_data_list = list.files(path, full.names = T, recursive = T, pattern = "bazi") |>
+        lapply(read_bazi_data)
+    names(bazi_data_list) <- lapply(bazi_data_list, getElement, "filename")
+    bazi_data_list
+}
+
+# Load working example data ####
+bazi_examples = c(
+    load_bazi_dir("data/zTest_data/Biproportional_problems/Diverse"),
+    load_bazi_dir("data/zTest_data/NZZ_problems/Diverse"),
+    load_bazi_dir("data/zTest_data/NZZ_problems/AH1-AH14"),
+    load_bazi_dir("data/zTest_data/NZZ_problems/Tied_cases/AS1.bazi"),
+    # tied votes are actually broken in alternate scaling
+    "data/zTest_data/NZZ_problems/Tied_cases/AS1.bazi" = list(read_bazi_data("data/zTest_data/NZZ_problems/Tied_cases/AS1.bazi"))
+    )
+
+# Remove datasets with issues ####
+# typo: XI as district name instead of IX
+bazi_examples[["data/zTest_data/Biproportional_problems/Diverse/MLB-michigan.bazi"]] <- NULL
+
+# typo: EINGABE only with 2 instead of 3 values (missing ",")
+bazi_examples[["data/zTest_data/Biproportional_problems/Diverse/Swiss2003Sim5006M.bazi"]] <- NULL
+
+# parsing: additional undefined column between party and votes
+bazi_examples[["data/zTest_data/NZZ_problems/Diverse/FP1.bazi"]] <- NULL
+
+# Run workable datasets, expecting no errors ####
+for(bazi_data in bazi_examples) {
+    testthat::expect_no_error(pukelsheim_bazi(bazi_data))
+}
+
+# Load edge case datasets ####
+bazi_errors = c(
+    load_bazi_dir("data/zTest_data/Biproportional_problems/Nonexistence"),
+    load_bazi_dir("data/zTest_data/NZZ_problems/Tied_cases")
+)
+
+# Remove datasets with issues ####
+# method: use a winner-take-TWO method (not implemented in proporz) and has no result even with intended method
+bazi_errors[["data/zTest_data/Biproportional_problems/Nonexistence/SM3.bazi"]] <- NULL
+bazi_errors[["data/zTest_data/Biproportional_problems/Nonexistence/SM4.bazi"]] <- NULL
+
+# The following examples lead to a "iterations exceeded" error that is not caught beforehand
+bazi_errors[["data/zTest_data/Biproportional_problems/Nonexistence/FG3.bazi"]] <- NULL # flow criterion check in bazi uses district sets
+bazi_errors[["data/zTest_data/NZZ_problems/Tied_cases/AS2.bazi"]] <- NULL # "2 gleichberechtige Unterzuteilungen"
+bazi_errors[["data/zTest_data/NZZ_problems/Tied_cases/mlb1.bazi"]] <- NULL # "2 gleichberechtige Unterzuteilungen"
+bazi_errors[["data/zTest_data/NZZ_problems/Tied_cases/AH2.bazi"]] <- NULL # "2 gleichberechtige Unterzuteilungen"
+
+# data sets that don't acutally lead to errors
+bazi_errors <- bazi_errors[setdiff(names(bazi_errors), names(bazi_examples))]
+
+# Expect errors in edge case datasets ####
+for(bazi_data in bazi_errors) {
+	testthat::expect_error(
+	    pukelsheim_bazi(bazi_data),
+	    "(Result is undefined, tied votes)|(Result is undefined, equal quotient)|(Result is undefined, cannot assign)|(Not enough seats)")
+}

--- a/inst/test-read_bazi_data.R
+++ b/inst/test-read_bazi_data.R
@@ -1,0 +1,15 @@
+# BAZI Dataset (data.zip) available from:
+# https://www.tha.de/Geistes-und-Naturwissenschaften/Data-Science/BAZI.html
+# Direct URL: https://www.tha.de/Binaries/Binary78393/data.zip
+# Extract to "data/" folder
+
+source("bazi.R")
+
+bazi_files = list.files("data",
+                        full.names = TRUE,
+                        recursive = TRUE,
+                        pattern = "\\.bazi$")
+
+for(.bazi_file in bazi_files) {
+    testthat::expect_no_error(read_bazi_data(.bazi_file))
+}

--- a/inst/test-read_bazi_data_coverage.R
+++ b/inst/test-read_bazi_data_coverage.R
@@ -1,0 +1,1 @@
+covr::report(covr::file_coverage("bazi.R", "test-read_bazi_data.R"))

--- a/tests/testthat/test-biproportional.R
+++ b/tests/testthat/test-biproportional.R
@@ -149,7 +149,7 @@ test_that("undefined result biproportional", {
 
     vm5 = matrix(c(10, 10, 10, 10), 2, 2)
     expect_error_fixed(biproporz(vm5, c(3,1)),
-                       "Result is undefined, exceeded maximum number of iterations")
+                       "Result is undefined, cannot assign all seats in lower apportionment")
 
     # manual fix (actual implementation depends on rules)
     vm4 <- vm6 <- vm
@@ -435,4 +435,9 @@ test_that("error messages", {
     expect_error_fixed(prep_votes_matrix(vm_names, "x"), "rownames in `x` must be unique")
     rownames(vm_names) <- c("A", "C", "B")
     expect_error_fixed(prep_votes_matrix(vm_names, "x"), "colnames in `x` must be unique")
+
+    # max iterations
+    options(proporz_max_iterations = 2)
+    expect_error_fixed(biproporz(vm, seats), "Result is undefined, exceeded maximum number of iterations (2)")
+    options(proporz_max_iterations = NULL)
 })

--- a/tests/testthat/test-biproportional.R
+++ b/tests/testthat/test-biproportional.R
@@ -135,7 +135,7 @@ test_that("flow criterion check for almost empty matrix", {
     expect_error_fixed(
         lower_apportionment(matrix(c(0, 10, 15, 0, 0, 20, 10, 0, 10, 0, 0, 20), 4),
                             c(3,1,1), c(2,1,1,1)),
-        "Not enough seats for party 1 in district 3\n(2 seats necessary, 1 available)")
+        "Not enough seats for parties 1, 4 in district 3\n(3 seats necessary, 1 available)")
 
     expect_error_fixed(
         biproporz(matrix(c(1000,10,0,1), 2), c(1,1)),
@@ -155,6 +155,12 @@ test_that("flow criterion check for almost empty matrix", {
     expect_error_fixed(
         biproporz(vm3b, c(A=1,B=4,C=3)),
         "Not enough seats for party 'TWO' in districts 'A', 'C'\n(6 seats necessary, 4 available)")
+
+    # check in multiple districts
+    expect_error_fixed(
+        check_flow_criterion(matrix(c(1,1,1,0,0,0, 1,0,0,1,1,0, 0,0,0,0,0,1), nrow = 6),
+                             c(2,2,2), c(1,1,1,1,1,1)),
+        "Not enough seats for parties 1, 2, 3, 4, 5 in districts 1, 2\n(5 seats necessary, 4 available)")
 
     vm_blocks1 = matrix(c(12L, 10L, 0L, 0L, 5L, 5L, 0L, 0L, 0L, 0L, 6L, 10L, 0L, 0L, 10L, 5L),
                         nrow = 4L, ncol = 4L,
@@ -176,26 +182,18 @@ test_that("flow criterion check for almost empty matrix", {
     expect_error(biproporz(vm_blocks3, uri2020$seats_vector),
                  "Not enough seats for parties 'CVP', 'SVP' in district 'Erstfeld'")
 
-    # no submatrix error for matrix with diag = 0
+     # no submatrix error for matrix with diag = 0
     vm_diag = matrix(c(0, 20, 100, 20, 0, 20, 100, 100, 0), nrow = 3)
     expect_is(biproporz(vm_diag, c(50, 30, 90)), "proporz_matrix")
+})
 
-    # too many parties for flow criterion check
-    set.seed(1)
-    vm_big1 = matrix(round(runif(60*20, 10, 1000)), nrow = 60)
-    expect_is(biproporz(vm_big1, rep(10, 20), use_list_votes = FALSE),
-              "proporz_matrix")
-    # shouldn't take longer than vm_big1
-    vm_big2 = matrix(round(runif(16*20, 10, 1000)), nrow = 16)
-    expect_is(biproporz(vm_big2, rep(10, 20), use_list_votes = FALSE),
-              "proporz_matrix")
-    # find cutoff point
-    # for(np in 10:25) {
-    #     print(c(np, system.time({
-    #         biproporz(matrix(round(runif(np*20, 10, 1000)), nrow = np),
-    #                   rep(10, 20), use_list_votes = FALSE)
-    #     })))
-    # }
+test_that("flow criterion helper", {
+    M = matrix(c(T,T,F,T,F,F,T,F,F,F,T,F,F,F,T), byrow = TRUE, ncol = 3)
+    expect_false(is_flow_criterion_pair(c(FALSE,FALSE),c(TRUE,FALSE)))
+    expect_false(is_flow_criterion_pair(c(TRUE,FALSE),c(FALSE,FALSE)))
+    expect_equal(apply(M, 1, is_flow_criterion_pair, M[1,]), c(TRUE, TRUE, TRUE, TRUE, FALSE))
+    expect_equal(apply(M, 1, is_flow_criterion_pair, M[2,]), c(FALSE, TRUE, TRUE, FALSE, FALSE))
+    expect_equal(apply(M, 1, is_flow_criterion_pair, M[5,]), c(FALSE, FALSE, FALSE, FALSE, TRUE))
 })
 
 test_that("undefined result biproportional", {

--- a/tests/testthat/test-biproportional.R
+++ b/tests/testthat/test-biproportional.R
@@ -158,6 +158,17 @@ test_that("undefined result biproportional", {
     ua4 = upper_apportionment(vm4, seats)
     ua6 = upper_apportionment(vm6, seats)
     expect_identical(ua4$party[4], ua6$party[6])
+
+    # fully tied
+    vdf = data.frame(
+        party = rep(c("A", "B", "C", "D", "E"), 5),
+        district = rep(c("d1", "d2", "d3", "d4", "d5"), each = 5L),
+        votes = rep(c(0.2, 0.5, 0.2, 0.5, 0.2, 0.5, 0.2, 0.5, 0.2),
+                    c(2L, 3L, 2L, 5L, 3L, 2L, 3L, 2L, 3L)))
+    vdf_seats = data.frame(
+        district = c("d1", "d2", "d3", "d4", "d5"),
+        seats = rep(1L, 5L))
+    expect_error(pukelsheim(vdf, vdf_seats), "Result is undefined, tied votes and multiple possible seat assignments")
 })
 
 test_that("find_divisor", {

--- a/tests/testthat/test-biproportional.R
+++ b/tests/testthat/test-biproportional.R
@@ -30,10 +30,9 @@ test_that("lower apportionment", {
     x3 = lower_apportionment(M2, d2, p2, method = function(x) ceil_at(x, 0.5))
     expect_identical(x3, x2)
 
-    expect_warning(
-        lower_apportionment(matrix(c(1,0,1,0), 2), c(1,1), c(2,0), method = "harmonic"),
-        'Lower apportionment is only guaranteed to terminate with the default Sainte-Lagu\u00EB/Webster method (method = "round")',
-        fixed = TRUE)
+    expect_identical(sum(
+        lower_apportionment(matrix(c(1,0,1,0), 2), c(1,1), c(2,0), method = "harmonic")),
+        2L)
 
     # exact 0.5 seats edge case
     vm0.5 = matrix(c(10, 10, 20, 10), 2, 2)

--- a/tests/testthat/test-biproportional.R
+++ b/tests/testthat/test-biproportional.R
@@ -128,7 +128,35 @@ test_that("almost empty vote_matrix", {
     vm3 = matrix(c(4,3,0,20,1,0), nrow = 2)
     expect_error_fixed(
         biproporz(vm3, c(1,3,4)),
-        "Result is undefined, cannot assign all seats in lower apportionment")
+        "Not enough seats for party '2' in all districts with non-zero votes (6 seats necessary, available at most: 4)")
+
+    vm4 = matrix(c(5,0,0,0,15,16), nrow = 3)
+    expect_error_fixed(
+        lower_apportionment(vm4, c(3,1), c(2,1,1)), # almost impossible to trigger with biproporz
+        "Not enough seats in district '1' (3 seats necessary, available at most: 2)")
+
+    rownames(vm3) <- c("ONE", "TWO")
+    expect_error_fixed(
+        biproporz(vm3, c(1,3,4)),
+        "Not enough seats for party 'TWO' in all districts with non-zero votes (6 seats necessary, available at most: 4)")
+
+    expect_error_fixed(
+        biproporz(matrix(c(1000,10,0,1), 2), c(1,1)),
+        "Not enough seats for party '1' in all districts with non-zero votes (2 seats necessary, available at most: 1)")
+
+    vm_blocks = matrix(c(12L, 10L, 0L, 0L, 5L, 5L, 0L, 0L, 0L, 0L, 6L, 10L, 0L, 0L, 10L, 5L),
+                       nrow = 4L, ncol = 4L,
+                       dimnames = list(party = c("A", "B", "C", "D"),
+                                       district = c("District 1", "District 2", "District 3", "District 4")))
+    seats_blocks = c(`District 1` = 5L, `District 2` = 5L, `District 3` = 5L, `District 4` = 6L)
+    expect_error_fixed(biproporz(vm_blocks, seats_blocks),
+                       "Not enough seats available in submatrix [c(1,2), c(1,2)]")
+    expect_error_fixed(biproporz(vm_blocks[c(4,3,1,2),c(1,3,2,4)], seats_blocks[c(1,3,2,4)]),
+                       "Not enough seats available in submatrix [c(3,4), c(1,3)]")
+
+    # no submatrix error for matrix with diag = 0
+    vm_diag = matrix(c(0, 20, 100, 20, 0, 20, 100, 100, 0), nrow = 3)
+    expect_is(biproporz(vm_diag, c(50, 30, 90)), "proporz_matrix")
 })
 
 test_that("undefined result biproportional", {

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -67,4 +67,12 @@ test_that("collapse_names", {
     y = c(2, 6, 67)
     expect_identical(collapse_names(x), "'Abc', 'XYZ'")
     expect_identical(collapse_names(y), "2, 6, 67")
+    expect_identical(collapse_names(c(T,F,T), c("A", "X", "B")), "'A', 'B'")
+})
+
+test_that("num_word", {
+    expect_identical(num_word("party", "parties", 1), "party")
+    expect_identical(num_word("party", "parties", 2), "party")
+    expect_identical(num_word("party", "parties", c(2, 3)), "parties")
+    expect_identical(num_word("party", "parties", c(T, F)), "party")
 })


### PR DESCRIPTION
With this PR, most errors created by undefined `biproporz()` results are caught earlier and more specific error messages are issued. The main improvement is the implementation of the 'flow criterion check' as described by [K.F. Oelbermann](https://www.sciencedirect.com/science/article/abs/pii/S0165489616000147):
> The flow-criterion is violated if the total number of seats of some set of parties exceeds the number of seats that are rewarded to the districts in which these parties campaign.

Previously, a lot of those errors were only caught when the maximum number of iterations was reached. Other error checks described in the paper have been implemented as well.

This PR also adds a script to read [BAZI example data](https://www.tha.de/Geistes-und-Naturwissenschaften/Data-Science/BAZI.html) with `read_bazi_data()`. The biproportional apportionment datasets have been used to test the updated code. The script files are stored in `inst/` and not exported as I can't provide the dataset with the package and the parsing function is a bit cobbled together.

`biproporz()` no longer warns if the chosen method is not "round". The method is just guaranteed to terminate in non-edge cases, so the constant warning if another method was chosen was a bit overeager. 