### PR TITLE
pukelsheim() returns tibble for tibble input

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # proporz (dev)
 
 * `proporz::proporz()` can now be used without calling `library(proporz)`
+* `pukelsheim()` returns tibbles for tibble input
 * Additional checks and error messages
 
 # proporz 1.5.1

--- a/R/S3.R
+++ b/R/S3.R
@@ -63,3 +63,13 @@ print.proporz_matrix_summary = function(x, ...) {
     print.data.frame(x, row.names = FALSE, right = TRUE)
     invisible(x)
 }
+
+.as_tibble = function(df) {
+    tibble_attr = c("class", "row.names", "names")
+    attributes(df) <- attributes(df)[c(tibble_attr, setdiff(names(attributes(df)), tibble_attr))]
+
+    attr(df, "class") <- c("tbl_df", "tbl", "data.frame")
+    attr(df, "row.names") <- c(NA, -nrow(df))
+
+    return(df)
+}

--- a/R/biproportional.R
+++ b/R/biproportional.R
@@ -189,10 +189,12 @@ pukelsheim = function(votes_df, district_seats_df,
                       sort = FALSE,
                       by = colnames(votes_df)[1:2])
 
+    # store divisors
+    attributes(return_df)$divisors <- attributes(m)$divisors
+
     # as_tibble, remove groups
     if(inherits(votes_df, "tbl_df")) {
-        class(return_df) <- c("tbl_df", "tbl", "data.frame")
+        return_df <- .as_tibble(return_df)
     }
-    attributes(return_df)$divisors <- attributes(m)$divisors
     return(return_df)
 }

--- a/R/biproportional.R
+++ b/R/biproportional.R
@@ -136,8 +136,8 @@ biproporz = function(votes_matrix,
 #' @seealso This function calls [biproporz()] after preparing the input data.
 #'
 #' @returns A data.frame like `votes_df` with a new column denoting the number seats per
-#'   party and district. Party and district divisors stored in attributes in attributes
-#'   (hidden from print, see [get_divisors()]).
+#'   party and district. Party and district divisors stored in attributes (hidden from print,
+#'   see [get_divisors()]). A ungrouped tibble is returned if `votes_df` is a tibble.
 #'
 #' @examples
 #' # Zug 2018
@@ -184,11 +184,15 @@ pukelsheim = function(votes_df, district_seats_df,
 
     # join with original table
     assert(nrow(votes_df) <= nrow(seats_df))
-    return_df = merge(votes_df,
-                      seats_df,
+    return_df = merge(as.data.frame(votes_df),
+                      as.data.frame(seats_df),
                       sort = FALSE,
                       by = colnames(votes_df)[1:2])
-    class(return_df) <- class(votes_df)
+
+    # as_tibble, remove groups
+    if(inherits(votes_df, "tbl_df")) {
+        class(return_df) <- c("tbl_df", "tbl", "data.frame")
+    }
     attributes(return_df)$divisors <- attributes(m)$divisors
     return(return_df)
 }

--- a/man/pukelsheim.Rd
+++ b/man/pukelsheim.Rd
@@ -45,8 +45,8 @@ they are entitled to a seat in the upper apportionment. Default is \code{FALSE}.
 }
 \value{
 A data.frame like \code{votes_df} with a new column denoting the number seats per
-party and district. Party and district divisors stored in attributes in attributes
-(hidden from print, see \code{\link[=get_divisors]{get_divisors()}}).
+party and district. Party and district divisors stored in attributes (hidden from print,
+see \code{\link[=get_divisors]{get_divisors()}}). A ungrouped tibble is returned if \code{votes_df} is a tibble.
 }
 \description{
 Method to proportionally allocate seats among parties/lists and

--- a/tests/testthat/test-biproportional.R
+++ b/tests/testthat/test-biproportional.R
@@ -89,6 +89,7 @@ test_that("pukelsheim wrapper", {
                        "District ids not found in second column of `x`. Are columns in the correct order (party, district, votes)?")
 
     result = pukelsheim(pklshm, pklshm_seats, new_seats_col = "Sitze")
+    expect_identical(class(result), "data.frame")
     expect_identical(result[,1:3], pklshm)
     expect_identical(result$Sitze, as.integer(c(1,2,1,1,2,2,2,1,3)))
     expect_false(is.null(get_divisors(result)$districts))
@@ -203,4 +204,38 @@ test_that("different method for upper and lower app", {
                            use_list_votes = FALSE,
                            method = list("floor", "round"))
     expect_identical(bip19_list, bip19)
+})
+
+test_that("non-data.frames", {
+    # tibble
+    grouped_tibble = structure(
+        list(Liste = c(1L, 1L, 1L, 2L, 2L, 2L, 3L, 3L, 3L),
+             Wahlkreis = c("A", "B", "C", "A", "B", "C", "A", "B", "C"),
+             Stimmen = c(51, 98, 45, 60, 100, 120, 63, 102, 144)),
+        class = c("grouped_df", "tbl_df", "tbl", "data.frame"),
+        row.names = c(NA, -9L),
+        groups = structure(list(
+            Liste = 1:3,
+            .rows = structure(list(1:3, 4:6, 7:9), ptype = integer(0), class = c("vctrs_list_of", "vctrs_vctr", "list"))),
+            class = c("tbl_df", "tbl", "data.frame"),
+            row.names = c(NA, -3L),
+            .drop = TRUE))
+
+    seats_tibble = structure(
+        list(Wahlkreis = c("A", "B", "C"), Sitze = 4:6),
+        class = c("tbl_df", "tbl", "data.frame"), row.names = c(NA, -3L))
+
+    p1 = pukelsheim(grouped_tibble, seats_tibble)
+    expect_is(p1, "tbl_df")
+    expect_identical(colnames(p1)[1:3], colnames(grouped_tibble))
+
+    # data.table is returned as data.frame
+    dt = structure(
+        list(Liste = c(1L, 1L, 1L, 2L, 2L, 2L, 3L, 3L, 3L),
+             Wahlkreis = c("A", "B", "C", "A", "B", "C", "A", "B", "C"),
+             Stimmen = c(51, 98, 45, 60, 100, 120, 63, 102, 144)),
+        row.names = c(NA, -9L), class = c("data.table", "data.frame"), .internal.selfref = NA)
+
+    p2 = pukelsheim(dt, seats_tibble)
+    expect_identical(class(p2), "data.frame")
 })

--- a/tests/testthat/test-biproportional.R
+++ b/tests/testthat/test-biproportional.R
@@ -229,6 +229,9 @@ test_that("non-data.frames", {
     expect_is(p1, "tbl_df")
     expect_identical(colnames(p1)[1:3], colnames(grouped_tibble))
 
+    p2 = pukelsheim(as.data.frame(grouped_tibble), seats_tibble)
+    expect_identical(get_divisors(p1), get_divisors(p2))
+
     # data.table is returned as data.frame
     dt = structure(
         list(Liste = c(1L, 1L, 1L, 2L, 2L, 2L, 3L, 3L, 3L),
@@ -236,6 +239,6 @@ test_that("non-data.frames", {
              Stimmen = c(51, 98, 45, 60, 100, 120, 63, 102, 144)),
         row.names = c(NA, -9L), class = c("data.table", "data.frame"), .internal.selfref = NA)
 
-    p2 = pukelsheim(dt, seats_tibble)
-    expect_identical(class(p2), "data.frame")
+    p3 = pukelsheim(dt, seats_tibble)
+    expect_identical(class(p3), "data.frame")
 })


### PR DESCRIPTION
Closes #18. Before this PR, `pukelsheim()` could not handle grouped tibbles:
``` r
library(proporz)
library(dplyr)

votes_df = as_tibble(finland2019$votes_df)

# tibble might still have groups from previous analysis
votes_df <- group_by(votes_df, party_name, district_name)

p = pukelsheim(votes_df, finland2019$district_seats_df)

print(p)
#> Error in `group_data()`:
#> ! `.data` must be a valid <grouped_df> object.
#> Caused by error in `validate_grouped_df()`:
#> ! The `groups` attribute must be a data frame.
```

The issue was that pukelsheim assigned `votes_df`'s classes to the returned data.frame:

```r
class(return_df) <- class(votes_df)
```

However, grouped tibbles also have the class `grouped_df` which then lead to issues with print because other grouping attributes were missing.

**In short**
* `pukelsheim()` returns now (ungrouped) tibbles if the input `votes_df` already is a tibble.
* In any other case (including `data.table`) a simple `data.frame` is returned.
* No dependency on dplyr/tibble is needed.

```` r
library(proporz)
library(dplyr)

votes_df = finland2019$votes_df |>
    as_tibble() |>
    group_by(party_name, district_name)

pukelsheim(votes_df, finland2019$district_seats_df)
#> # A tibble: 229 × 4
#>    party_name district_name  votes seats
#>    <chr>      <chr>          <int> <int>
#>  1 KOK        UUS           114243     7
#>  2 SDP        UUS            97107     7
#>  3 VIHR       HEL            90662     5
#>  4 PS         UUS            86691     6
#>  5 KOK        HEL            84141     4
#>  6 KESK       OUL            78486     6
#>  7 VIHR       UUS            73626     5
#>  8 SDP        PIR            66109     5
#>  9 SDP        KAA            59722     4
#> 10 KOK        PIR            55244     3
#> # ℹ 219 more rows
```
